### PR TITLE
fix: support camelcase type names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,12 @@
         "": {
             "name": "@kapeta/language-target-react-ts",
             "version": "local",
+            "bundleDependencies": [
+                "@kapeta/codegen-target",
+                "@kapeta/nodejs-process",
+                "prettier",
+                "snake-case"
+            ],
             "license": "MIT",
             "dependencies": {
                 "@kapeta/codegen-target": "<2",
@@ -3023,6 +3029,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@kapeta/codegen-target/-/codegen-target-1.0.1.tgz",
             "integrity": "sha512-dsHDDBSu4TJ5JlWdReRsidSkrgQiUQyNwoEcwSx1ehwoix3MJ8WuErKdzDRdG7KXeXk7UDiTAumf62jYK5huYw==",
+            "inBundle": true,
             "dependencies": {
                 "handlebars": "4.1.2",
                 "lodash": "4.17.11",
@@ -3033,6 +3040,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
             "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+            "inBundle": true,
             "dependencies": {
                 "neo-async": "^2.6.0",
                 "optimist": "^0.6.1",
@@ -3051,17 +3059,20 @@
         "node_modules/@kapeta/codegen-target/node_modules/lodash": {
             "version": "4.17.11",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "inBundle": true
         },
         "node_modules/@kapeta/codegen-target/node_modules/minimist": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-            "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
+            "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+            "inBundle": true
         },
         "node_modules/@kapeta/codegen-target/node_modules/optimist": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+            "inBundle": true,
             "dependencies": {
                 "minimist": "~0.0.1",
                 "wordwrap": "~0.0.2"
@@ -3071,6 +3082,7 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
             "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+            "inBundle": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -3121,7 +3133,8 @@
         "node_modules/@kapeta/nodejs-process": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@kapeta/nodejs-process/-/nodejs-process-1.1.0.tgz",
-            "integrity": "sha512-9eojgB2s0XTzFfgQwNEp0lY6VwgL3HbdVZc6hYpwravbmbuBrrK3tjdUufgDA4ERhGELuKoHYEUuZGLiyUyc6g=="
+            "integrity": "sha512-9eojgB2s0XTzFfgQwNEp0lY6VwgL3HbdVZc6hYpwravbmbuBrrK3tjdUufgDA4ERhGELuKoHYEUuZGLiyUyc6g==",
+            "inBundle": true
         },
         "node_modules/@kapeta/prettier-config": {
             "version": "0.6.0",
@@ -4863,6 +4876,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
             "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "inBundle": true,
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -8441,6 +8455,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
             "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "inBundle": true,
             "dependencies": {
                 "tslib": "^2.0.3"
             }
@@ -8608,12 +8623,14 @@
         "node_modules/neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "inBundle": true
         },
         "node_modules/no-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
             "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "inBundle": true,
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
@@ -9050,6 +9067,7 @@
             "version": "2.8.8",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "inBundle": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -9621,6 +9639,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
             "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+            "inBundle": true,
             "dependencies": {
                 "dot-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -9630,6 +9649,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "inBundle": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10122,7 +10142,8 @@
         "node_modules/tslib": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+            "inBundle": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -10266,6 +10287,7 @@
             "version": "3.17.4",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
             "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "inBundle": true,
             "optional": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
@@ -10740,6 +10762,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
             "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+            "inBundle": true,
             "engines": {
                 "node": ">= 14"
             }

--- a/templates/kapeta/resource-type-rest-client/browser.restclient.ts.hbs
+++ b/templates/kapeta/resource-type-rest-client/browser.restclient.ts.hbs
@@ -5,7 +5,7 @@
 
 import { RestClient } from "@kapeta/sdk-web-rest-client";
 {{#eachTypeReference data.spec.methods all=true}}
-import { {{name}} } from "../../entities/{{name}}";
+import { {{type name}} } from "../../entities/{{type name}}";
 {{/eachTypeReference}}
 
 

--- a/templates/kapeta/resource-type-rest-client/server.restclient.ts.hbs
+++ b/templates/kapeta/resource-type-rest-client/server.restclient.ts.hbs
@@ -4,7 +4,7 @@
 //
 import {RestClient} from "@kapeta/sdk-rest-client";
 {{#eachTypeReference data.spec.methods all=true}}
-import { {{name}} } from "../../entities/{{name}}";
+import { {{type name}} } from "../../entities/{{type name}}";
 {{/eachTypeReference}}
 
 class {{type data.metadata.name}}Client {


### PR DESCRIPTION
We we named a entity something like blogPost the import code we generated
would be lowercase, but the code expects it to be uppercase.