### PR TITLE
fix: add missing schemas dependency in prod mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "bundleDependencies": [
                 "@kapeta/codegen-target",
                 "@kapeta/nodejs-process",
+                "@kapeta/schemas",
                 "prettier",
                 "snake-case"
             ],
@@ -17,6 +18,7 @@
             "dependencies": {
                 "@kapeta/codegen-target": "<2",
                 "@kapeta/nodejs-process": "^1.1.0",
+                "@kapeta/schemas": "<2",
                 "prettier": "^2.8.8",
                 "snake-case": "^3.0.4"
             },
@@ -35,7 +37,6 @@
                 "@kapeta/codegen": "<2",
                 "@kapeta/eslint-config": "^0.6.0",
                 "@kapeta/prettier-config": "^0.6.0",
-                "@kapeta/schemas": "<2",
                 "@kapeta/ui-web-types": "<2",
                 "@tsconfig/node18": "^1.0.1",
                 "babel-loader": "^8.2.5",
@@ -3175,7 +3176,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@kapeta/schemas/-/schemas-0.3.0.tgz",
             "integrity": "sha512-8RlMS+Z91QhpChPl3/c/sCRLBsdYD7E5HjbMISwdSVl4MWUD8yxVoGBy6F9s9Gx2twMx6rR8/Kan/cZlW0RViQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ajv": "^8.12.0",
                 "lodash": "^4.17.21"
@@ -3979,7 +3980,7 @@
             "version": "8.12.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -5726,7 +5727,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
@@ -8638,7 +8639,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -8771,7 +8772,7 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -9493,7 +9494,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6"
             }
@@ -9710,7 +9711,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10798,7 +10799,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "@kapeta/codegen-target": "<2",
         "@kapeta/nodejs-process": "^1.1.0",
+        "@kapeta/schemas": "<2",
         "prettier": "^2.8.8",
         "snake-case": "^3.0.4"
     },
@@ -46,7 +47,6 @@
         "@kapeta/codegen": "<2",
         "@kapeta/eslint-config": "^0.6.0",
         "@kapeta/prettier-config": "^0.6.0",
-        "@kapeta/schemas": "<2",
         "@kapeta/ui-web-types": "<2",
         "@tsconfig/node18": "^1.0.1",
         "babel-loader": "^8.2.5",


### PR DESCRIPTION
Fix for:
```
Failed to load target: kapeta/language-target-react-ts:0.1.0 Error: Cannot find module '@kapeta/schemas'
```

Move the schemas dependency to prod deps, since we're not install devDeps when loading assets.