### PR TITLE
fix: put larger files as separate resources [CORE-1262]

### DIFF
--- a/templates/kapeta/block-type-frontend/globals.d.ts
+++ b/templates/kapeta/block-type-frontend/globals.d.ts
@@ -1,0 +1,18 @@
+//#FILENAME:src/globals.d.ts:create-only
+// Type definitions for image imports
+declare module '*.jpg' {
+    const content: string;
+    export default content;
+}
+declare module '*.png' {
+    const content: string;
+    export default content;
+}
+declare module '*.gif' {
+    const content: string;
+    export default content;
+}
+declare module '*.svg' {
+    const content: string;
+    export default content;
+}

--- a/templates/kapeta/block-type-frontend/webpack.development.config.js.hbs
+++ b/templates/kapeta/block-type-frontend/webpack.development.config.js.hbs
@@ -86,7 +86,11 @@ const config = {
                 test: /\.ya?ml$/,
                 use: ["json-loader", "yaml-loader"],
                 include: Path.resolve(__dirname, "./"),
-            }
+            },
+            {
+                test: /\.(jpg|png|gif|woff|woff2|eot|ttf|svg)$/,
+                type: 'asset',
+            },
         ],
     },
     resolve: {

--- a/test/resources/examples/portal/src/globals.d.ts
+++ b/test/resources/examples/portal/src/globals.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for image imports
+declare module '*.jpg' {
+    const content: string;
+    export default content;
+}
+declare module '*.png' {
+    const content: string;
+    export default content;
+}
+declare module '*.gif' {
+    const content: string;
+    export default content;
+}
+declare module '*.svg' {
+    const content: string;
+    export default content;
+}

--- a/test/resources/examples/portal/webpack.development.config.js
+++ b/test/resources/examples/portal/webpack.development.config.js
@@ -78,6 +78,10 @@ const config = {
                 use: ['json-loader', 'yaml-loader'],
                 include: Path.resolve(__dirname, './'),
             },
+            {
+                test: /\.(jpg|png|gif|woff|woff2|eot|ttf|svg)$/,
+                type: 'asset',
+            },
         ],
     },
     resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,10 @@ module.exports = {
                 use: ['yaml-loader'],
                 include: Path.resolve(__dirname, './'),
             },
+            {
+                test: /\.(jpg|png|gif|woff|woff2|eot|ttf|svg)$/,
+                type: 'asset',
+            },
         ],
     },
     devtool: process.env.NODE_ENV === 'production' ? 'source-map' : 'inline-source-map',


### PR DESCRIPTION
Automatically inline images less than 8kb, and emit larger files as resources.
